### PR TITLE
Fix bug: when pull to refresh more, table view will scroll to top.

### DIFF
--- a/GDDataDrivenView/Classes/Layout/GDDBaseViewLayout.m
+++ b/GDDataDrivenView/Classes/Layout/GDDBaseViewLayout.m
@@ -128,9 +128,13 @@ static NSString *const sectionsPath = @"sections";
   dispatch_async(dispatch_get_main_queue(), ^{
       if ([view isKindOfClass:UITableView.class]) {
         UITableView *tableView = view;
-        [tableView beginUpdates];
-        [tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationNone];
-        [tableView endUpdates];
+        if (view.infiniteScrollingView.state == SVInfiniteScrollingStateLoading) {
+          [tableView reloadData];
+        } else {
+          [tableView beginUpdates];
+          [tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationNone];
+          [tableView endUpdates];
+        }
       } else if ([view isKindOfClass:UICollectionView.class]) {
         UICollectionView *collectionView = view;
         [collectionView performBatchUpdates:^{


### PR DESCRIPTION
Fix bug: when pull to refresh more, table view will scroll to top. Use reloadData method instead of insertrowsAtIndexPaths:withRowAnimation: to fix it
